### PR TITLE
Add 'restartSurvey' endpoint to API documentation

### DIFF
--- a/api-reference/endpoints/v1/restartSurvey.mdx
+++ b/api-reference/endpoints/v1/restartSurvey.mdx
@@ -1,0 +1,21 @@
+---
+title: 'Restart Survey'
+openapi: 'POST /restartSurvey'
+--- 
+
+A **restarted survey resumes accepting new respondents**, allowing further additions after being previously stopped.
+
+```json Example response
+{
+    "success": true,
+    "message": "Survey successfully restarted",
+    "results": {
+        "surveyId": "68e4f174adc679a59fe16324",
+        "surveyName": "Test Import Redirect 12",
+        "status": "RUNNING",
+        "previousStatus": "STOPPED"
+    }
+}
+```
+
+

--- a/api-reference/endpoints/v2/restartSurvey.mdx
+++ b/api-reference/endpoints/v2/restartSurvey.mdx
@@ -1,0 +1,21 @@
+---
+title: 'Restart Survey'
+openapi: 'POST /v2/restartSurvey'
+--- 
+
+A **restarted survey resumes accepting new respondents**, allowing further additions after being previously stopped.
+
+```json Example response
+{
+    "success": true,
+    "message": "Survey successfully restarted",
+    "results": {
+        "surveyId": "68e4f174adc679a59fe16324",
+        "surveyName": "Test Import Redirect 12",
+        "status": "RUNNING",
+        "previousStatus": "STOPPED"
+    }
+}
+```
+
+

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1849,8 +1849,125 @@
                   "success": true,
                   "message": "Survey successfully stopped",
                   "results": {
+                    "surveyId": "68e4f174adc679a59fe16324",
                     "surveyName": "Global Vacation Insights 2024",
                     "status": "STOPPED"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "When a request fails due to invalid input or other errors, the API returns a 400 Bad Request status code. The response includes a descriptive `message` explaining the issue and an `error` object containing additional details to aid in diagnosing and resolving the problem.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "title": "Validation Error",
+                      "description": "Indicating a validation failure, the response includes a `message` field specifying the issue and an `errors` object listing the missing or incorrect fields to help clients resolve them. \n\n **⭕ Note:** Refer to the [response structure](/api-reference/api-specifications/response-structure) for the format of the error response.", 
+                      "type": "object"
+                    },
+                    {
+                      "title": "Survey not found",
+                      "description": "This error occurs when the **requested survey does not exist in the system**. It may happen if the survey name is incorrect, has been deleted, or was never created. \n\n **⭕ Note:** Refer to the [response structure](/api-reference/api-specifications/response-structure) for the format of the error response.",
+                      "type": "object"
+                    }
+                  ]
+                },
+                "examples": {
+                  "Validation Error": {
+                    "value": {
+                      "success":false,
+                      "message":"Validation Error",
+                      "errors":{
+                        "0": "\"surveyName\" is required"
+                      }
+                    }
+                  },
+                  "Survey not found": {
+                    "value": {
+                      "success":false,
+                      "message":"Survey not found",
+                      "errors":{}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/restartSurvey": {
+      "post": {
+        "tags": [
+          "Survey"
+        ],
+        "summary": "Restart a survey",
+        "operationId": "restartSurvey",
+        "description": "API endpoint for restarting a survey. This can be triggered to resume a previously stopped survey.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetAllRespondentsRequest"
+              },
+              "example": {
+                "surveyName": "Global Vacation Insights 2024"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Upon successful processing, the API returns a 200 OK status code along with the expected data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success":{
+                      "type":"boolean",
+                      "description":"A variable indicating whether the **operation was successful**.",
+                      "enum":[true,false]
+                    },
+                    "message":{
+                      "type":"string",
+                      "description":"A variable that **human-readable message** providing additional context or confirmation of the requested action."
+                    },
+                    "results": {
+                      "type": "object",
+                      "description": "This object serves as a **container to hold the results for the requested data**, encapsulating all relevant information and outputs in a structured format.",
+                      "properties": {
+                        "surveyId": {
+                          "type": "string",
+                          "description": "A variable that **indicates the unique survey identifier**."
+                        },
+                        "surveyName": {
+                          "type": "string",
+                          "description": "A variable that **indicates the survey name**."
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "A variable that **indicates the status of the survey**. \n\n **⭕ Note:** ReDem surveys have two possible statuses: `RUNNING` and `STOPPED`. The survey status will be updated to `RUNNING` once the survey is restarted."
+                        },
+                        "previousStatus": {
+                          "type": "string",
+                          "description": "A variable that **indicates the previous status of the survey** before the restart."
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "message": "Survey successfully restarted",
+                  "results": {
+                    "surveyId": "68e4f174adc679a59fe16324",
+                    "surveyName": "Global Vacation Insights 2024",
+                    "status": "RUNNING",
+                    "previousStatus": "STOPPED"
                   }
                 }
               }
@@ -2790,8 +2907,125 @@
                   "success": true,
                   "message": "Survey successfully stopped",
                   "results": {
+                    "surveyId": "68e4f174adc679a59fe16324",
                     "surveyName": "Global Vacation Insights 2024",
                     "status": "STOPPED"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "When a request fails due to invalid input or other errors, the API returns a 400 Bad Request status code. The response includes a descriptive `message` explaining the issue and an `error` object containing additional details to aid in diagnosing and resolving the problem.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "title": "Validation Error",
+                      "description": "Indicating a validation failure, the response includes a `message` field specifying the issue and an `errors` object listing the missing or incorrect fields to help clients resolve them. \n\n **⭕ Note:** Refer to the [response structure](/api-reference/api-specifications/response-structure) for the format of the error response.", 
+                      "type": "object"
+                    },
+                    {
+                      "title": "Survey not found",
+                      "description": "This error occurs when the **requested survey does not exist in the system**. It may happen if the survey name is incorrect, has been deleted, or was never created. \n\n **⭕ Note:** Refer to the [response structure](/api-reference/api-specifications/response-structure) for the format of the error response.",
+                      "type": "object"
+                    }
+                  ]
+                },
+                "examples": {
+                  "Validation Error": {
+                    "value": {
+                      "success":false,
+                      "message":"Validation Error",
+                      "errors":{
+                        "0": "\"surveyName\" is required"
+                      }
+                    }
+                  },
+                  "Survey not found": {
+                    "value": {
+                      "success":false,
+                      "message":"Survey not found",
+                      "errors":{}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/restartSurvey": {
+      "post": {
+        "tags": [
+          "Survey"
+        ],
+        "summary": "Restart a survey",
+        "operationId": "restartSurveyV2",
+        "description": "API endpoint for restarting a survey. This can be triggered to resume a previously stopped survey.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetAllRespondentsRequest"
+              },
+              "example": {
+                "surveyName": "Global Vacation Insights 2024"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Upon successful processing, the API returns a 200 OK status code along with the expected data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success":{
+                      "type":"boolean",
+                      "description":"A variable indicating whether the **operation was successful**.",
+                      "enum":[true,false]
+                    },
+                    "message":{
+                      "type":"string",
+                      "description":"A variable that **human-readable message** providing additional context or confirmation of the requested action."
+                    },
+                    "results": {
+                      "type": "object",
+                      "description": "This object serves as a **container to hold the results for the requested data**, encapsulating all relevant information and outputs in a structured format.",
+                      "properties": {
+                        "surveyId": {
+                          "type": "string",
+                          "description": "A variable that **indicates the unique survey identifier**."
+                        },
+                        "surveyName": {
+                          "type": "string",
+                          "description": "A variable that **indicates the survey name**."
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "A variable that **indicates the status of the survey**. \n\n **⭕ Note:** ReDem surveys have two possible statuses: `RUNNING` and `STOPPED`. The survey status will be updated to `RUNNING` once the survey is restarted."
+                        },
+                        "previousStatus": {
+                          "type": "string",
+                          "description": "A variable that **indicates the previous status of the survey** before the restart."
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "message": "Survey successfully restarted",
+                  "results": {
+                    "surveyId": "68e4f174adc679a59fe16324",
+                    "surveyName": "Global Vacation Insights 2024",
+                    "status": "RUNNING",
+                    "previousStatus": "STOPPED"
                   }
                 }
               }

--- a/docs.json
+++ b/docs.json
@@ -99,6 +99,7 @@
                   "api-reference/endpoints/v2/addRespondent",
                   "api-reference/endpoints/v2/getRespondent",
                   "api-reference/endpoints/v2/getAllRespondents",
+                  "api-reference/endpoints/v2/restartSurvey",
                   "api-reference/endpoints/v2/stopSurvey",
                   "api-reference/endpoints/v2/creditCalculation"
                 ]
@@ -190,6 +191,7 @@
                   "api-reference/endpoints/v1/addRespondent",
                   "api-reference/endpoints/v1/getRespondent",
                   "api-reference/endpoints/v1/getAllRespondents",
+                  "api-reference/endpoints/v1/restartSurvey",
                   "api-reference/endpoints/v1/stopSurvey",
                   "api-reference/endpoints/v1/creditCalculation"
                 ]


### PR DESCRIPTION
- Introduced new API endpoint for restarting surveys in both v1 and v2.
- Updated 'docs.json' to include references to the new endpoint.
- Added detailed documentation for the 'restartSurvey' endpoint in both v1 and v2 markdown files, including request and response examples.