### PR TITLE
Remove example response from 'restartSurvey' endpoint documentation i…

### DIFF
--- a/api-reference/endpoints/v1/restartSurvey.mdx
+++ b/api-reference/endpoints/v1/restartSurvey.mdx
@@ -5,17 +5,4 @@ openapi: 'POST /restartSurvey'
 
 A **restarted survey resumes accepting new respondents**, allowing further additions after being previously stopped.
 
-```json Example response
-{
-    "success": true,
-    "message": "Survey successfully restarted",
-    "results": {
-        "surveyId": "68e4f174adc679a59fe16324",
-        "surveyName": "Test Import Redirect 12",
-        "status": "RUNNING",
-        "previousStatus": "STOPPED"
-    }
-}
-```
-
 

--- a/api-reference/endpoints/v2/restartSurvey.mdx
+++ b/api-reference/endpoints/v2/restartSurvey.mdx
@@ -4,18 +4,3 @@ openapi: 'POST /v2/restartSurvey'
 --- 
 
 A **restarted survey resumes accepting new respondents**, allowing further additions after being previously stopped.
-
-```json Example response
-{
-    "success": true,
-    "message": "Survey successfully restarted",
-    "results": {
-        "surveyId": "68e4f174adc679a59fe16324",
-        "surveyName": "Test Import Redirect 12",
-        "status": "RUNNING",
-        "previousStatus": "STOPPED"
-    }
-}
-```
-
-


### PR DESCRIPTION
…n v1 and v2 markdown files to streamline content.