### PR TITLE
Fix CHS interviewData validation docs: 300 pairs, not 1000

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1210,7 +1210,7 @@
             "items": {
               "$ref": "#/components/schemas/InterviewData_v2"
             },
-            "description": "This variable aggregates all relevant question-answer pairs used to evaluate the respondent's coherence. \n\n 🧪 **Validations:**  \n - A **maximum of 1000** question/answer pairs are allowed per respondent.",
+            "description": "This variable aggregates all relevant question-answer pairs used to evaluate the respondent's coherence. \n\n 🧪 **Validations:**  \n - A **maximum of 300** question/answer pairs are allowed per respondent.",
             "example": [{
               "questionId": "Q1",
               "question": "What type of accommodation did you stay in?",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The OpenAPI schema for `CHSDataPoint_v2` (`interviewData` under CHS on `addRespondent`) still described a **maximum of 1000** question/answer pairs. The actual limit is **300** (already noted in the API changelog).

## Changes

- Updated the `interviewData` description in `api-reference/openapi.json` for the v2 CHS schema used by v3 `addRespondent` so the validations section states **300** pairs.

This aligns generated / Mintlify API reference with the product behavior and the existing changelog entry.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://repdata.slack.com/archives/C0ADY0JFSDQ/p1777039331159179?thread_ts=1777039331.159179&cid=C0ADY0JFSDQ)

<div><a href="https://cursor.com/agents/bc-99567654-2bc8-504e-9dff-cc9b8e48147f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99567654-2bc8-504e-9dff-cc9b8e48147f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

