### PR TITLE
docs(api): add retentionDays field to respondentAttributes in OpenAPI…

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1167,6 +1167,11 @@
               "panel": "Panel Name",
               "country": "United States"
             }
+          },
+          "retentionDays":{
+            "type": "number",
+            "description": "**The number of days to retain the respondent's data**. \n\n **💡Important:** If no retention days are specified, the respondent's data will be retained indefinitely. \n\n **🔦 Tip:** You can use this field to specify the number of days to retain the respondent's data. For example, if you want to retain the respondent's data for 30 days, you can set this field to 30.",
+            "example": 30
           }
         }
       },
@@ -4192,7 +4197,8 @@
                 "respondentAttributes": {
                   "panel": "Panel Name",
                   "country": "United States"
-                }
+                },
+                "retentionDays": 30
               }
             }
           }

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1170,7 +1170,7 @@
           },
           "retentionDays":{
             "type": "number",
-            "description": "**The number of days to retain the respondent's data**. \n\n **💡Important:** If no retention days are specified, the respondent's data will be retained indefinitely. \n\n **🔦 Tip:** You can use this field to specify the number of days to retain the respondent's data. For example, if you want to retain the respondent's data for 30 days, you can set this field to 30.",
+            "description": "**The number of days to retain the respondent's data**. \n\n Use this in case you have specific requirements for data retention. After the retention period is over the respondent will be deleted from ReDem. The data will be no longer available in our platform.",
             "example": 30
           }
         }


### PR DESCRIPTION
… schema

Introduced a new field, retentionDays, to specify the number of days to retain respondent data. Updated the OpenAPI documentation to include a description and example usage for this field.